### PR TITLE
Sync changes for Bio-Formats 5.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>bio-formats-tools</artifactId>
-  <version>5.8.0-SNAPSHOT</version>
+  <version>5.8.2</version>
 
   <name>Bio-Formats command line tools</name>
   <description>Bio-Formats command line tools for reading and converting files</description>
@@ -148,7 +148,7 @@
   </dependencies>
 
   <properties>
-    <bioformats.version>5.7.3</bioformats.version>
+    <bioformats.version>5.8.2</bioformats.version>
     <imagej1.version>1.52a</imagej1.version>
     <logback.version>1.1.1</logback.version>
     <slf4j.version>1.7.6</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,6 @@
 
   <properties>
     <bioformats.version>5.8.2</bioformats.version>
-    <imagej1.version>1.52a</imagej1.version>
     <logback.version>1.1.1</logback.version>
     <slf4j.version>1.7.6</slf4j.version>
     <testng.version>6.8</testng.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,10 +73,10 @@
   </prerequisites>
 
   <scm>
-    <connection>scm:git:https://github.com/ome/bio-formats-imagej</connection>
-    <developerConnection>scm:git:git@github.com:ome/bio-formats-imagej</developerConnection>
+    <connection>scm:git:https://github.com/ome/bio-formats-tools</connection>
+    <developerConnection>scm:git:git@github.com:ome/bio-formats-tools</developerConnection>
     <tag>HEAD</tag>
-    <url>http://github.com/ome/bio-formats-imagej</url>
+    <url>http://github.com/ome/bio-formats-tools</url>
   </scm>
   <issueManagement>
     <system>Trac</system>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
 
   <properties>
     <bioformats.version>5.7.3</bioformats.version>
-    <imagej1.version>1.48s</imagej1.version>
+    <imagej1.version>1.52a</imagej1.version>
     <logback.version>1.1.1</logback.version>
     <slf4j.version>1.7.6</slf4j.version>
     <testng.version>6.8</testng.version>


### PR DESCRIPTION
See [trello](https://trello.com/c/IaqwRcg6/22-update-repositories-for-582).

Same as https://github.com/ome/bio-formats-imagej/pull/3 but we zero code changes (version bumps only).

Testing: Check jobs are green.  Try `bftools` from `https://web-proxy.openmicroscopy.org/east-ci/job/BIOFORMATS-merge/jdk=JDK9,label=testintegration/ws/bio-formats-build/bio-formats-bundles/bftools/target/`